### PR TITLE
fixed adc sample doubling bug in demux-1 mode

### DIFF
--- a/jasper_library/hdl_sources/adc16_interface/adc_unit.vhd
+++ b/jasper_library/hdl_sources/adc16_interface/adc_unit.vhd
@@ -162,7 +162,7 @@ architecture adc_unit_arc of adc_unit is
                                           & adc_iserdes_data_a_pipelined( 7 downto  0)
                                           & adc_iserdes_data_b_pipelined( 7 downto  0);
 
-           when others => adc_iserdes_data <= adc_iserdes_data_a_pipelined;
+           when others => adc_iserdes_data <= adc_iserdes_data_b_pipelined;
          end case;
        end if;
      end process;


### PR DESCRIPTION
Remember the bug from earlier this summer with the ROACH2 ADC16's in demux1 mode where they doubled each sample? Same thing is happening with SNAP, and I think this fixes it.
