### PR TITLE
Changed the hardware locations for the GPIO LEDs.

### DIFF
--- a/jasper_library/platforms/snap.yaml
+++ b/jasper_library/platforms/snap.yaml
@@ -70,12 +70,12 @@ pins:
   led:
     iostd: LVCMOS25
     loc:
-      - D13
-      - D14
-      - E12
-      - E13
       - C13
       - C14
+      - D13
+      - D14 
+      - E12
+      - E13
   eth_clk_p:
     loc:
       - K6


### PR DESCRIPTION
Modifications were made in the following file:
mlib_devel/jasper_library/platforms/snap.yaml
In lines 73 - 78 the mapping used to be:
- D13
- D14
- E12
- E13
- C13
- C14
  Now the mapping is as follows:
- C13
- C14
- D13
- D14
- E12
- E13
