### PR TITLE
Remove start_done and start_reg from i2c_master_byte_ctrl.v

### DIFF
--- a/jasper_library/hdl_sources/i2c/i2c_master_byte_ctrl.v
+++ b/jasper_library/hdl_sources/i2c/i2c_master_byte_ctrl.v
@@ -198,17 +198,6 @@ module i2c_master_byte_ctrl (
 	//
 	reg [4:0] c_state; // synopsys enum_state
 
-    // Jack
-    reg start_reg = 1'b0;
-    reg start_done = 1'b0;
-    always @(posedge clk) begin
-        if (start) begin
-            start_reg <= start;
-        end else if (start_done) begin
-            start_reg <= 1'b0;
-        end
-    end
-
 	always @(posedge clk or negedge nReset)
 	  if (!nReset)
 	    begin
@@ -237,15 +226,13 @@ module i2c_master_byte_ctrl (
 	      shift    <= #1 1'b0;
 	      ld       <= #1 1'b0;
 	      cmd_ack  <= #1 1'b0;
-          start_done <= 1'b0;
 
 	      case (c_state) // synopsys full_case parallel_case
 	        ST_IDLE:
 	          if (go)
 	            begin
-	                if (start_reg)
+	                if (start)
 	                  begin
-                          start_done <= 1'b1;
 	                      c_state  <= #1 ST_START;
 	                      core_cmd <= #1 `I2C_CMD_START;
 	                  end


### PR DESCRIPTION
I have looked into the I2C hdl code a little bit with Xilinx ILA. The copy that we originally had from the opencores website actually works. If you need a start signal at the beginning of an I2C transaction, you have to feed the command register with CMD_START and CMD_READ/CMD_WRITE/CMD_STOP simultaneously. The is determined by the lines 232-356 in [i2c_master_byte_ctrl.v](https://github.com/ianmalcolm/mlib_devel/blob/jasper_devel/jasper_library/hdl_sources/i2c/i2c_master_byte_ctrl.v). The start state will be triggered only when the wire "go" (logic "OR" between read, write and stop) goes high.