### PR TITLE
Fix LMX2581 read problem of SNAP board

### DIFF
--- a/jasper_library/platforms/snap.yaml
+++ b/jasper_library/platforms/snap.yaml
@@ -391,7 +391,7 @@ pins:
     loc: J15
   lmx2581_muxout:
     iostd: LVCMOS33
-    loc: G16
+    loc: J19
   lmx2581_le:
     iostd: LVCMOS33
     loc: J16


### PR DESCRIPTION
Fix the FPGA's connection to lmx2581_muxout, which can serve as a register readback pin.
Demonstration of the read functionality of LMX2581 can be found at [https://github.com/ianmalcolm/HERADev/blob/adc_devel/frequencysynthesizer.py](url)